### PR TITLE
feat: added copilot.lua and documented Git tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ iTerm under Preferences -> Profile -> Text.
 
 - `<leader>cc` Jump to the top of the current indent level
 
-### Projects
+### Working with Projects
 
 [ahmedkhalf/project.nvim](https://github.com/ahmedkhalf/project.nvim)
 
-- `[leader]fp` to open the project finder
-- [project key maps](https://github.com/ahmedkhalf/project.nvim#telescope-mappings)
-  are available inside the project finder window
+From the start page, you move to the Projects line and type `<CR>` (or type
+`<leader>se` for settings). This will open Telescope with a list of your
+previously opened projects. Select a project from the list (`<C-n/p><CR>`) and
+then search for a file to open and select it with `<CR>`. Now your current
+working directory is the project root.
 
 Projects are added by starting nvim (or calling `:cd path/to/project`) in any
 folder with a `.git` folder and then opening a code file. Additional project
@@ -68,23 +70,80 @@ folder patterns can be configured in `config/plugins/project.lua`.
 > I've had some issues with projects showing up. Sometimes you need to open a
 > project folder multiple times before it's detected.
 
-### Git
+- `<leader>fp` to open the project finder
+- [project key maps](https://github.com/ahmedkhalf/project.nvim#telescope-mappings)
+  are available inside the project finder window
 
-#### [GitDiff](https://github.com/sindrets/diffview.nvim)
+### Working with the autocomplete
 
-GitSigns shows you the removed/added/staged hunks in files, nvim tree and the
-status line. You can browse the git hunks in a file with 
+- [Nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
+  The generic autocomplete popup that opens as you type. See `h: nvim-cmp` for
+  help.
+- [copilot.lua](https://github.com/zbirenbaum/copilot.lua)
+  Copilot plugin written in lua for better performance. See GitHub page for
+  help.
 
-- `<leader>cm` Git commits in Telescope 
+When in insert mode, you should get an autocomplete menu. Use `<C-space>` in
+insert mode to open or close the dialog. When the dialog is open, use `<C-n/p>`
+to navigate to the next/previous items. You will also see Copilot suggestions
+written as ghost text after your cursor which you can accept using `<Tab>` (in
+insert mode).
+
+If you select an item marked "Snippet" in the autocomplete, it will populate the
+snippet code for you and place you in the first edit location for that snippet.
+You can now type some text and then type `<Tab>` to move to the next edit
+location. Repeat until there are no more edit locations.
+
+> NOTE: I've noticed a couple bugs in our current implementation.
+> - If the copilot suggestion is show before the autocomplete, you can't toggle
+>   the autocomplete window.
+> - If the documentation window is open, you cannot `Tab` complete a copilot
+>   suggestion.
+> - Copilot suggestions and snippet navigation sometimes conflict. We should
+>   disable copilot while we are in a snippet.
+
+### Working with Git
+
+- [GitSigns](https://github.com/lewis6991/gitsigns.nvim)
+  Shows you the removed/added/staged hunks within your open buffers, nvim tree and the status line.
+  Try `:Gitsigns <TAB>` to view the available commands or `h: Gitsigns` for
+  help.
+- [GitDiff](https://github.com/sindrets/diffview.nvim)
+  A diff viewer for Git staging and navigationg the Git history.
+  Try `:Diffview<TAB>` to view available commands or `h: Diffivew` for help.
+- [NeoGit](https://github.com/TimUntersberger/neogit)
+  An easy UI for performing Git commands. Visit GitHub for help.
+
+When working in a file, the number column will show you unstaged file changes
+with a colored bar. Type `]c` and `[c` to navigate between changes in the file. You
+can stage/unstage changes with `<leader>cs` (Commits Stage) and the left column color
+will be removed. You can also quickly show a diff of the unstaged lines with
+`<leader>cd` (Commits Diff). Or you can toggle an inline view of all unstaged
+changes with `<leader>ch` (Commits Highlight).
+
+You can quickly review your current Git changes in a floating window by pressing
+`<leader>gt` (Git Telescope). Use `<C-n/p>` to show the diff of the next/previous file. Use
+`<C-d/u>` to scroll the preview window up/down. Use `?` to show Telescope key
+commands at the bottom of the screen.
+
+For a more complete staging experience, you can use `<leader>gs` (Git Stage) to
+open a new tab with a diff view of the current Git state. Use `j/k` to
+navigate between files and `<CR>` to show the diff for the selected file. The
+Gitsigns commands work in the diff buffers as well so you can jump between
+hunks, stage them, etc.
+
+#### Cheatsheat
+
 - `<leader>gt` Git status in Telescope
 - `]c` Go to next Git hunk
 - `[c` Go to previous Git hunk
-
-In addition to the 
-plugin, you also have access to [GitDiff](https://github.com/sindrets/diffview.nvim)
-which allows you to view Git diffs of your working tree or history. Diffs are
-opened in a new tab. Use `<leader>gs` (Git Status) to toggle the diff view of
-your current working tree. See `h: diffview` for documentation.
+- `<leader>cs` Stage hunk under cursor
+- `<leader>ch` Show inline git changes
+- `<leader>td` Show file diff
+- `<leader>gs` Show the project wide git changes
+- `<leader>gg` Git GUI
+- `<leader>cm` Browse Git commits in Telescope 
+- `<leader>gh` View detailed Git history in a tab
 
 ### Github Copilot
 https://github.com/github/copilot.vim - This works after adding `vim.g.copilot_assume_mapped = true` to `config/init.lua`
@@ -110,70 +169,6 @@ move to the next edit location, repeat...
 - A good overview of [lua config with Neovim](https://vonheikemen.github.io/devlog/tools/configuring-neovim-using-lua/)
 - The official [Neovim configuration with lua guide](https://neovim.io/doc/user/lua-guide.html#lua-guide)
 
-## TODO
-
-- [C-space] should close the autocomplete if it is open
-- Change git next/prev hunk command to also show the hunk diff
-- [Esc] in terminal conflicts with vimify in ZSH
-- [Enter] in insert mode doesn't indent correctly in JSX
-- TODO highlighting in JSX
-- use Shift + j/k in place of [C-n]/[C-p]?
-- use Shift + h/l in place of $/0? If so remove the key switching config I put
-in
-- scroll to left/right edge without moving cursor in normal and insert modes
-- scroll up/down by 5 lines without moving cursor in normal and insert modes
-- navigate up/down by 10 lines
-- navigate back/forward inside camel case words
-- [leader]] doesn't seem to work
-- surround plugin (ex: cs')
-- hide autocomplete with escape or [C-c]
-- hide floating error text (show on hover)
-- re-paste last pasted content
-- keybindng to jump to beginning of line
-- prettier/eslint 
-- show file name at top or bottom of each window
-- Tmux [C-HJKL] integeration (Temporary?)
-- keymap to clear terminal scrollback
-- keymap for [Up] [Down] in terminal ([D-Up/Down]?)
-- [leader]b last buffer
-- s keymap for :w
-- sa keymap for :wa
-- Different minwidth for terminal windows
-- color border or background of focused window
-  https://github.com/blueyed/vim-diminactive
-- [leader]b to go back to previous buffer
-- prevent terminal window from entering terminal mode when the cursor enters it?
-- Esc to exit lsp.hover modal (ie. KK will open hover and focus it but it's hard
-to exit...use [C-J])
-- keymap to jump to open terminal if there is one
-- open url:
-https://stackoverflow.com/questions/68694479/how-do-i-open-a-link-in-google-chrome-in-lua-for-neovim
-- colorize console log statements in jest output (or maybe just use a jest
-plugin)
-- autocomplete suggestions should prioritize fields first
-- close all hidden buffers
-- checktime of open buffers when vim window regains focus
-- change zsh cursor to an insert cursor
-- only turn on line highlight for the current buffer
-- keymap to show the row and column highlight in a bright color so I can find
-the cursor
-- close GitSigns preview window with [Esc]. See https://github.com/lewis6991/gitsigns.nvim/issues/385
-
-Plugins:
-- split join
-- surround
-- Gundo
-- Taboo?
-- jest.nvim?
-- system status graph
-
-### New things to add
-
-- terminal autocomplete
-- comment function by typing [leader]/ inside the body of the function
-- keymap to show time in big letters
-- plugin to flash the screen when a calendar event happens
-- Alt and Cmd backspace/delete to delete full words?
 
 ### Neovide
 
@@ -195,6 +190,7 @@ Plugins:
 
 - Read about the [plugins that come with NvChad](https://github.com/NvChad/NvChad)
 - Read the default key mappings provided in `NvChad/lua/core/mappings.lua`
+- [Getting started with NeoVim](https://bryankegley.me/posts/nvim-getting-started/)
 - Learn how to [customize NvChad](https://nvchad.com/config/Walkthrough)
 - Learn how to customize [NeoVim options with lua](https://vonheikemen.github.io/devlog/tools/configuring-neovim-using-lua/)
 
@@ -203,7 +199,7 @@ Plugins:
 To perform a project wide search and replace...
 
 - `<leader>fw` to search the project for the text you want to replace
-- `[Ctrl-q]` to move the search results to the quickfix window
+- `<Ctrl-q>` to move the search results to the quickfix window
 - type `cdo s/{SEARCH_TEXT}/{REPLACEMENT_TEXT}/g` or (use `/gc` to manually
   approve each change)
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,19 @@ folder patterns can be configured in `config/plugins/project.lua`.
 
 When in insert mode, you should get an autocomplete menu. Use `<C-space>` in
 insert mode to open or close the dialog. When the dialog is open, use `<C-n/p>`
-to navigate to the next/previous items. You will also see Copilot suggestions
-written as ghost text after your cursor which you can accept using `<Tab>` (in
-insert mode).
+(or `<C-j/k>`) to navigate to the next/previous items. When you have an item
+selected, `<CR>` will select it.
+
+Additionally, you may also see Copilot suggestions written as ghost text after
+your cursor which you can accept using `<Tab>` (in insert mode). You can scroll
+to the next/previous Copilot suggestion using `<C-n/p>`. You can hide the
+Copilot suggestions with `<C-space>`. 
+
+If you have both the autocomplete window and copilot visible, the key commands
+for the autocomplete take precendence. If you actually want to interact with
+Copilot and ignore the autocomplete suggestions, use `<C-space>` once to hide
+the autocomplete so you can interact with Copilot. If you want to hide both
+the autocomplete and Copilot, type `<C-space>` twice.
 
 If you select an item marked "Snippet" in the autocomplete, it will populate the
 snippet code for you and place you in the first edit location for that snippet.
@@ -101,6 +111,39 @@ location. Repeat until there are no more edit locations.
 >   suggestion.
 > - Copilot suggestions and snippet navigation sometimes conflict. We should
 >   disable copilot while we are in a snippet.
+
+#### Cheatsheat
+
+- `<C-space>` toggle the autocomplete menu when in insert mode or hide the
+  Copilot suggestions if they are visible.
+- `<C-j/k>` cycle through the autocomplete or Copilot suggestions
+- `<C-n/p>` cycle through the autocomplete or Copilot suggestions
+- `<Tab>` accept the copilot ghost text suggestion
+
+### Working with code
+
+Code errors are displayed in the number gutter and as ghost text. You can jump
+between errors using `]d` (next diagnostic) and `[d` (previous diagnostic). This
+will show you the error message in a popup. Use `<leader>ca` (code action) to
+populate the command line with a list of autofix suggestions. Follow the
+instructions to fix the error.
+
+When hovered over any code, you can use `K` to show the type of that code. This
+is really useful if you need to debug Typescript errors.
+
+#### Cheatsheat
+
+- `]d` Go to the next error (diagnostic)
+- `[d` Go to the previous error (diabnostic)
+- `<leader>ca` Autofix an error (code action)
+- `K` to show code type info
+- `/` search file forwards (`n` and `p` to jump next/previous)
+- `?` search file backwards (`n` and `p` to jump next/previous in reverse)
+- `<leader>cc` to jump up one scope block level
+- `%` to jump to the matching surrounding character (ie. quote, paren, curly, etc.)
+- `zz` to center the code under your cursor
+- `}` go to the next empty line
+- `{` go to the previous empty line
 
 ### Working with Git
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,75 @@
+## TODO
+
+- [C-Space] should show the autocomplete when a copilot suggestion is visible
+- Undo last autocomplete suggestion when in insert mode (ie. if you `<C-n>` to
+  select an item, you should be able to revert back to your previous typing with
+  a different binding)
+- Undo copilot suggestion (ie. if you tab complete a copilot suggestion, you
+  should be able to undo that easily without leaving insert mode)
+- [C-o/O] in insert mode
+- remove leader u mapping
+- find an undo tree plugin that works with telescope
+- find a lua clipboard history
+- [C-space] should close the autocomplete if it is open
+- Change git next/prev hunk command to also show the hunk diff
+- [Esc] in terminal conflicts with vimify in ZSH
+- [Enter] in insert mode doesn't indent correctly in JSX
+- Prevent autopairs when completing a copilot suggestion
+- Close the "go-to-definition" (ie [leader]gd) window after selecting an item
+- TODO highlighting in JSX
+- use Shift + j/k in place of [C-n]/[C-p]?
+- use Shift + h/l in place of $/0? If so remove the key switching config I put in
+- scroll to left/right edge without moving cursor in normal and insert modes
+- scroll up/down by 5 lines without moving cursor in normal and insert modes
+- navigate up/down by 10 lines
+- navigate back/forward inside camel case words
+- [leader]] doesn't seem to work
+- surround plugin (ex: cs')
+- hide autocomplete with escape or [C-c]
+- hide floating error text (show on hover)
+- re-paste last pasted content
+- keybindng to jump to beginning of line
+- prettier/eslint 
+- show file name at top or bottom of each window
+- Tmux [C-HJKL] integeration (Temporary?)
+- keymap to clear terminal scrollback
+- keymap for [Up] [Down] in terminal ([D-Up/Down]?)
+- [leader]b last buffer
+- s keymap for :w
+- sa keymap for :wa
+- Different minwidth for terminal windows
+- color border or background of focused window
+  https://github.com/blueyed/vim-diminactive
+- [leader]b to go back to previous buffer
+- prevent terminal window from entering terminal mode when the cursor enters it?
+- Esc to exit lsp.hover modal (ie. KK will open hover and focus it but it's hard
+to exit...use [C-J])
+- keymap to jump to open terminal if there is one
+- open url:
+https://stackoverflow.com/questions/68694479/how-do-i-open-a-link-in-google-chrome-in-lua-for-neovim
+- colorize console log statements in jest output (or maybe just use a jest
+plugin)
+- autocomplete suggestions should prioritize fields first
+- close all hidden buffers
+- checktime of open buffers when vim window regains focus
+- change zsh cursor to an insert cursor
+- only turn on line highlight for the current buffer
+- keymap to show the row and column highlight in a bright color so I can find
+the cursor
+- close GitSigns preview window with [Esc]. See https://github.com/lewis6991/gitsigns.nvim/issues/385
+
+Plugins:
+- split join
+- surround
+- Gundo
+- Taboo?
+- jest.nvim?
+- system status graph
+
+### New things to add
+
+- terminal autocomplete
+- comment function by typing [leader]/ inside the body of the function
+- keymap to show time in big letters
+- plugin to flash the screen when a calendar event happens
+- Alt and Cmd backspace/delete to delete full words?

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,8 @@
 - Undo last autocomplete suggestion when in insert mode (ie. if you `<C-n>` to
   select an item, you should be able to revert back to your previous typing with
   a different binding)
+- `K` should be able to close the type info. We should also be able to trigger
+  the type hover in insert mode.
 - Undo copilot suggestion (ie. if you tab complete a copilot suggestion, you
   should be able to undo that easily without leaving insert mode)
 - [C-o/O] in insert mode

--- a/config/highlights.lua
+++ b/config/highlights.lua
@@ -14,7 +14,21 @@ M.override = {
 }
 
 M.add = {
-  NvimTreeOpenedFolderName = { fg = "green", bold = true },
+  NvimTreeOpenedFolderName = { 
+    -- fg = "green",
+    bold = true
+  },
+  DiffAdd = {
+    fg = "green",
+  },
+  -- a yellow might be more obvious than blue
+  DiffChange = {
+    fg = "yellow",
+  },
+  DiffText = {
+    bg = "one_bg2",
+    bold = false,
+  },
 }
 
 return M

--- a/config/init.lua
+++ b/config/init.lua
@@ -6,7 +6,7 @@ require "custom.settings"
 local autocmd = vim.api.nvim_create_autocmd
 local autogrp = vim.api.nvim_create_augroup
 
-vim.g.copilot_assume_mapped = true
+-- vim.g.copilot_assume_mapped = true
 
 -- Auto resize panes when resizing nvim window
 -- autocmd("VimResized", {
@@ -14,6 +14,7 @@ vim.g.copilot_assume_mapped = true
 --   command = "tabdo wincmd =",
 -- })
 
+-- Change the background color of the currently active buffer window.
 -- TODO Use NvChad correctly
 -- vim.cmd[[highlight ActiveWindow ctermbg=0 guibg=lightgrey]]
 -- vim.cmd[[highlight ActiveWindow guibg=#17252c]]

--- a/config/mappings.lua
+++ b/config/mappings.lua
@@ -139,6 +139,18 @@ M.vimtree = {
 
 M.gitsigns = {
   n = {
+    ["<leader>cs"] = { "<cmd> Gitsigns stage_hunk <CR>", "Commits Stage: stage hunk at cursor" },
+    ["<leader>ch"] = {
+      function()
+        local gs = require('gitsigns')
+        gs.toggle_deleted(nil)
+        gs.toggle_word_diff(nil)
+        gs.toggle_linehl(nil)
+        gs.toggle_numhl(nil)
+      end,
+      "Commits Highlight: color the git changes in a file."
+    },
+    ["<leader>cd"] = { "<cmd> Gitsigns diffthis <CR>", "Commits Diff: diff unstaged lines"},
     ["]c"] = {
       function()
         if vim.wo.diff then

--- a/config/mappings.lua
+++ b/config/mappings.lua
@@ -24,6 +24,14 @@ M.disabled = {
 }
 
 M.general = {
+  i = {
+    ["<C-i>"] = {
+      function()
+        GetHighlightGroupUnderCursor()
+      end,
+      "Show Highlight: show the highlight group name under the cursor."
+    }
+  },
   n = {
     [";"] = { ":", "enter command mode", opts = { nowait = true } },
 
@@ -43,14 +51,12 @@ M.general = {
     -- TODO Only activate these in Neovide
     ["<C-=>"] = {
       function()
-        print("Zoom +")
         ChangeScaleFactor(1.25)
       end,
       "Zoom + (Neovide)",
     },
     ["<C-->"] = {
       function()
-        print('Zoom -')
         ChangeScaleFactor(1/1.25)
       end,
       "Zoom - (Neovide)",
@@ -83,6 +89,8 @@ M.general = {
 
     -- tabs
     ["<leader>ts"] = { ":tab split", "open current buffer in new tab"},
+    ["<D-]>"] = { ":tabnext", "Next tab" },
+    ["<D-[>"] = { ":tabprevious", "Previous tab" },
 
     -- window sizing/movement
     ["<Left>"] = { ":vertical resize -1<CR>", "resize window left"},

--- a/config/plugins/cmp.lua
+++ b/config/plugins/cmp.lua
@@ -1,0 +1,70 @@
+local present, cmp = pcall(require, "cmp")
+
+if not present then
+  print('Failed to load cmp')
+  return
+end
+
+local copilotPresent, copilot = pcall(require, "copilot.suggestion")
+
+if not copilotPresent then
+  print('Failed to load copilot')
+  return
+end
+
+local M = {}
+
+local has_words_before = function()
+  unpack = unpack or table.unpack
+  local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+  return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
+end
+
+-- local cmp = require("cmp")
+-- local luasnip = require("luasnip")
+
+M = {
+  mapping = {
+    -- ["<C-d>"] = cmp.mapping.scroll_docs(-4),
+    -- ["<C-f>"] = cmp.mapping.scroll_docs(4),
+    ["<C-Space>"] = cmp.mapping(function()
+      if cmp.visible() then
+        cmp.close()
+      else
+        cmp.complete()
+      end
+    end, {"i", "s"}),
+    ["<C-e>"] = nil,
+    ["<Tab>"] = cmp.mapping(function(fallback)
+      if require("luasnip").expand_or_jumpable() then
+        vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump", true, true, true), "")
+      elseif copilot.is_visible() then
+        if cmp.visible() then
+          cmp.close()
+        end
+        copilot.accept()
+      elseif has_words_before() then
+        cmp.complete()
+      else
+        fallback()
+      end
+    end, {
+      "i",
+      "s",
+    }),
+    ["<S-Tab>"] = cmp.mapping(function(fallback)
+      if require("luasnip").jumpable(-1) then
+        vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-jump-prev", true, true, true), "")
+      -- elseif luasnip.jumpable(-1) then
+      --   luasnip.jump(-1)
+      else
+        fallback()
+      end
+    end, {
+      "i",
+      "s",
+    }),
+  },
+}
+
+return M

--- a/config/plugins/cmp.lua
+++ b/config/plugins/cmp.lua
@@ -27,13 +27,6 @@ M = {
   mapping = {
     -- ["<C-d>"] = cmp.mapping.scroll_docs(-4),
     -- ["<C-f>"] = cmp.mapping.scroll_docs(4),
-    ["<C-Space>"] = cmp.mapping(function()
-      if cmp.visible() then
-        cmp.close()
-      else
-        cmp.complete()
-      end
-    end, {"i", "s"}),
     ["<C-e>"] = nil,
     ["<Tab>"] = cmp.mapping(function(fallback)
       if require("luasnip").expand_or_jumpable() then
@@ -45,8 +38,8 @@ M = {
         copilot.accept()
       elseif has_words_before() then
         cmp.complete()
-      else
-        fallback()
+      -- else
+      --   fallback()
       end
     end, {
       "i",
@@ -59,6 +52,62 @@ M = {
       --   luasnip.jump(-1)
       else
         fallback()
+      end
+    end, {
+      "i",
+      "s",
+    }),
+    ["<C-j>"] = cmp.mapping(function(fallback)
+      if cmp.visible() then
+        cmp.select_next_item()
+      elseif copilot.is_visible() then
+        copilot.next()
+      else
+        fallback()
+      end
+    end, {
+      "i",
+      "s",
+    }),
+    ["<C-k>"] = cmp.mapping(function(fallback)
+      if cmp.visible() then
+        cmp.select_prev_item()
+      elseif copilot.is_visible() then
+        copilot.prev()
+      else
+        fallback()
+      end
+    end, {
+      "i",
+      "s",
+    }),
+    ["<C-l>"] = cmp.mapping(function(fallback)
+      if cmp.visible() then
+        cmp.close()
+      else
+        fallback()
+      end
+    end, {
+      "i",
+      "s",
+    }),
+    -- My old version
+    -- ["<C-Space>"] = cmp.mapping(function()
+    --   if cmp.visible() then
+    --     cmp.close()
+    --   else
+    --     cmp.complete()
+    --   end
+    -- end, {"i", "s"}),
+    ["<C-Space>"] = cmp.mapping(function(fallback)
+      if cmp.visible() then
+        cmp.close()
+      elseif copilot.is_visible() then
+        copilot.dismiss()
+      else
+        cmp.complete()
+      -- else
+      --   fallback()
       end
     end, {
       "i",

--- a/config/plugins/init.lua
+++ b/config/plugins/init.lua
@@ -4,6 +4,13 @@ return {
 	-- To remove a default plugin:
 	-- ["hrsh7th/cmp-path"] = false,
 
+	-- CMP (autocomplete menu)
+	["hrsh7th/nvim-cmp"] = {
+    override_options = function()
+      return require('custom.plugins.cmp')
+    end,
+  },
+
 	-- Telescope
 	["nvim-telescope/telescope.nvim"] = {
 		-- TODO Do I need this?
@@ -77,8 +84,7 @@ return {
 	["ahmedkhalf/project.nvim"] = {
 		after = "telescope.nvim",
 		config = function()
-			-- require('telescope').load_extension 'projects'
-			require("custom.plugins.project").setup()
+			return require("custom.plugins.project").setup()
 		end,
 	},
 
@@ -93,7 +99,15 @@ return {
 	["TimUntersberger/neogit"] = {
 		requires = "nvim-lua/plenary.nvim",
 		config = function()
-			require("neogit").setup()
+			require("neogit").setup({
+				mappings = {
+					-- modify status buffer mappings
+					status = {
+						-- Close the neogit tab
+						["Q"] = "Close",
+					},
+				},
+			})
 		end,
 	},
 
@@ -105,17 +119,30 @@ return {
 		config = function()
 			require("copilot").setup({
 				-- Disable copilot suggestions UI because we will use CMP instead.
-				suggestion = { enabled = false },
-				panel = { enabled = false },
+				suggestion = {
+					auto_trigger = true,
+					-- enabled = false
+          keymap = {
+            accept = "<C-,>",
+          }
+				},
+				panel = {
+					auto_refresh = true,
+					-- enabled = false,
+				},
 			})
 		end,
 	},
 
-  -- Copilot in nvim-cmp window
-	["zbirenbaum/copilot-cmp"] = {
-		after = { "copilot.lua" },
-		config = function()
-			require("copilot_cmp").setup()
-		end,
-	},
+	-- Copilot in nvim-cmp window
+  -- TODO: This doesn't work yet.
+	-- ["zbirenbaum/copilot-cmp"] = {
+ --    -- after = 'copilot.lua',
+	-- 	after = { "copilot.lua" },
+	-- 	config = function()
+	-- 		require("copilot_cmp").setup({
+ --        method = "getCompletionsCycling",
+ --      })
+	-- 	end,
+	-- },
 }

--- a/config/plugins/init.lua
+++ b/config/plugins/init.lua
@@ -92,6 +92,18 @@ return {
 	-- Show git tree diffs in a dedicated tab page.
 	["sindrets/diffview.nvim"] = {
 		requires = "nvim-lua/plenary.nvim",
+    config = function()
+      print('setup diffview')
+      require("diffview").setup({
+        file_panel = {
+          listing_style = "list",             -- One of 'list' or 'tree'
+          tree_options = {                    -- Only applies when listing_style is 'tree'
+            flatten_dirs = true,              -- Flatten dirs that only contain one single dir
+            folder_statuses = "only_folded",  -- One of 'never', 'only_folded' or 'always'.
+          },
+        },
+      })
+    end
 	},
 
 	-- neogit
@@ -122,9 +134,9 @@ return {
 				suggestion = {
 					auto_trigger = true,
 					-- enabled = false
-          keymap = {
-            accept = "<C-,>",
-          }
+          -- keymap = {
+          --   accept = "<C-,>",
+          -- }
 				},
 				panel = {
 					auto_refresh = true,

--- a/config/plugins/project.lua
+++ b/config/plugins/project.lua
@@ -28,13 +28,13 @@ local config = {
 
   -- When set to false, you will get a message when project.nvim changes your
   -- directory.
-  silent_chdir = true,
+  silent_chdir = false,
 
   -- What scope to change the directory, valid options are
   -- * global (default)
   -- * tab
   -- * win
-  scope_chdir = 'global',
+  scope_chdir = 'tab',
 
   -- Path where project.nvim will store the project history for use in
   -- telescope


### PR DESCRIPTION
### What does this PR do?

Integrates Copilot with `nvim-cmp`. Copilot previews are shown in ghost text while autocomplete suggestions appear in the normal dropdown. To get these two plugins playing nicely together I had to prevent the Tab key from cycling through autocomplete menu items. Instead, you'll need to use `<C-n>` and `<C-p>` (next/previous). I've also written a bunch of documentation around the interactions.

Long term, I think it might be better to move the copilot suggestions into the autocomplete dialog using `copilot-cmp` but I couldn't get it working.